### PR TITLE
Change hyprland-qtutils to hyprland-guiutils

### DIFF
--- a/install/pkgs.txt
+++ b/install/pkgs.txt
@@ -29,7 +29,7 @@ bc
 
 # Hyprland Ecosystem
 hyprland
-hyprland-qtutils
+hyprland-guiutils
 hyprland-qt-support
 hyprpaper
 hyprpicker


### PR DESCRIPTION
hyprland-qtutils should be replaced since has been superceded by [hyperland-guiutils](https://archlinux.org/packages/extra/x86_64/hyprland-guiutils/)