### PR TITLE
Fixed a problem with sudo -v

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 set -e
 
 DOTFILES_DIR="$HOME/.local/share/dotfiles"
-REPO_URL="https://github.com/fenrir22/dotfiles.git"
+REPO_URL="https://github.com/Maciejonos/dotfiles.git"
 
 echo "=============="
 echo "Dotfiles Setup"


### PR DESCRIPTION
During a clean installation, if more than 5 minutes passed, sudo stopped working, no longer allowing the installation of packages, having to restart the script